### PR TITLE
Add progress bar on top of the pane that floats on the left in diff view...

### DIFF
--- a/scripts/diff_begin.js
+++ b/scripts/diff_begin.js
@@ -139,3 +139,58 @@ function fixDarkLines() {
 }
 fixDarkLines();
 
+// Display progress bar reflecting the percentage of reviewed files
+// assuming that reviewer moves from the first file to last linearly.
+(function() {
+  var bar = null;
+
+  function showBar() {
+    if (bar !== null) {
+      return;
+    }
+
+    // Find pane that floats on the left in the patch view.
+    var pane = $("div > div > form[method='GET']").parent().parent();
+
+    // Inject a div at the top and move to be at the very top of the pane
+    // ignoring pane's padding.
+    bar = $("<div/>").css("margin-top", "-5px")
+                     .css("margin-left", "-5px")
+                     .css("margin-bottom", "5px")
+                     .css("margin-right", "-5px")
+                     .prependTo(pane);
+
+    // Find file select ("Jump to" one) on the same pane and use it
+    // to calculate progress percentage.
+    var select = pane.find("div > select").get(0);
+    var pct = select.selectedIndex * 100 / select.length;
+
+    // Create a percentage bar.
+    $("<div/>").height(5)
+               .width(pct * (pane.outerWidth() / 100))
+               .css("background-color", "lightslategray")
+               .prependTo(bar);
+  }
+
+  function hideBar() {
+    if (bar !== null) {
+      bar.remove();
+      bar = null;
+    }
+  }
+
+  function displayProgress() {
+    chrome.storage.sync.get(['displayProgress'] , function(items) {
+      if (items.displayProgress) {
+        showBar();
+      } else {
+        hideBar();
+      }
+    });
+  }
+
+  chrome.storage.onChanged.addListener(displayProgress, ['displayProgress']);
+
+  // When the DOM is ready.
+  $(displayProgress);
+})();

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -23,6 +23,11 @@ var manifest = {
       "default": true,
       "description": "Add breakpoints to Base URL."
     },
+    "displayProgress": {
+      "type": "bool",
+      "default": true,
+      "description": "Display review progress in the single patch view."
+    },
     "enableAnimations": {
       "type": "bool",
       "default": true,


### PR DESCRIPTION
During big reviews it is very helpful to know how many files are still lying ahead :-) 

This CL adds progress bar that allows to quickly estimate this

![screenshot-20130718 173356](https://f.cloud.github.com/assets/131846/820193/b03a050e-efbf-11e2-9c73-11fd17e12e87.png)
