### PR TITLE
Load Inconsolata with HTTPS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,6 @@
   font-family: 'Inconsolata';
   font-style: normal;
   font-weight: 400;
-  src: local('Inconsolata'), url(http://themes.googleusercontent.com/static/fonts/inconsolata/v6/BjAYBlHtW3CJxDcjzrnZCIbN6UDyHWBl620a-IRfuBk.woff) format('woff');
+  src: local('Inconsolata'), url(https://themes.googleusercontent.com/static/fonts/inconsolata/v6/BjAYBlHtW3CJxDcjzrnZCIbN6UDyHWBl620a-IRfuBk.woff) format('woff');
 }
 


### PR DESCRIPTION
Otherwise, the page loads mixed contents and the style breaks when mixed contents is not allowed.
